### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,20 +108,7 @@ class stackdriver (
       owner  => 'root',
       group  => 'root'
     }
-    file { '/etc/stackdriver/utils/sdsend.py':
-      ensure  => 'present',
-      source  => 'puppet:///modules/stackdriver/utils/sdsend.py',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0755'
-    }
-    file { '/etc/stackdriver/utils/sdsend6.py':
-      ensure  => 'present',
-      source  => 'puppet:///modules/stackdriver/utils/sdsend6.py',
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0755'
-    }
+    
     file { '/etc/stackdriver/utils/sdsend.sh':
       ensure  => 'present',
       source  => 'puppet:///modules/stackdriver/utils/sdsend.sh',


### PR DESCRIPTION
no longer need separate scripts for different centos versions.  Only need the wrapper script now.